### PR TITLE
Fixed version of libxml2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 1. Clone the submodule (the libxml2 library):
 ```bash
 git submodule update --init --recursive
+git reset --hard 1039cd53
 ```
 
 2. Build the libxml2 image:
@@ -43,6 +44,11 @@ To apply a patch from another person, use the following command:
 ./patch.sh apply <patch_file>
 # or apply all patches:
 ./patch.sh apply
+```
+
+To reset all patches, use:
+```bash
+./patch.sh reset
 ```
 
 You can rebuild the fuzzers with the following command. It uses the source code (for the fuzzers) in ./projects/libxml2 directory:

--- a/projects/libxml2/patch.sh
+++ b/projects/libxml2/patch.sh
@@ -98,16 +98,31 @@ function cmd_apply() {
   echo "${GREEN}All patches applied.${RESET}"
 }
 
+function cmd_reset() {
+    pushd "${SUBMODULE_PATH}" > /dev/null
+
+    echo "${BLUE}Resetting all changes...${RESET}"
+    git reset --hard 1039cd53
+    git clean -fd
+
+    popd > /dev/null
+    echo "${GREEN}All changes reset.${RESET}"
+}
+
 # Main dispatcher
 if [[ $# -lt 1 || $# -gt 2 ]]; then usage; fi
 
 case "$1" in
-  generate)
-    cmd_generate
+    generate)
+        cmd_generate
     ;;
-  apply)
-    if [[ $# -gt 2 ]]; then usage; fi
-    cmd_apply "${2:-}"
+    apply)
+        if [[ $# -gt 2 ]]; then usage; fi
+        cmd_apply "${2:-}"
     ;;
-  *) usage ;;
+    reset)
+        cmd_reset
+    ;;
+    *) usage
+    ;;
 esac


### PR DESCRIPTION
Added instructions to go to a fixed version of the library, and added command to patch.sh to revert to this version.

This comes from the observation that the library evolves, and for our testing, we must restrict ourselves to a single version.